### PR TITLE
Use header file referenced from script

### DIFF
--- a/as/compiler/asc.cpp
+++ b/as/compiler/asc.cpp
@@ -23,7 +23,7 @@
 llvm::cl::OptionCategory CompilerOptions("Compiler Options");
 
 llvm::cl::opt<std::string> inputFilename(llvm::cl::Positional, llvm::cl::desc("<input_filename>"), llvm::cl::Required, llvm::cl::value_desc("filename"), llvm::cl::cat(CompilerOptions));
-llvm::cl::opt<std::string> headerFilename("h", llvm::cl::desc("Header filename"), llvm::cl::value_desc("filename"), llvm::cl::cat(CompilerOptions));
+// llvm::cl::opt<std::string> headerFilename("h", llvm::cl::desc("Header filename"), llvm::cl::value_desc("filename"), llvm::cl::cat(CompilerOptions));
 llvm::cl::opt<std::string> outputFilename("o", llvm::cl::desc("Output filename"), llvm::cl::value_desc("filename"), llvm::cl::cat(CompilerOptions));
 
 static void printVersion(llvm::raw_ostream &out) {
@@ -72,11 +72,11 @@ int main(int argc, char **argv)
     // llvm::outs() << "Header file: " << headerFilename << "\n";
     // llvm::outs() << "Output file: " << outputFilename << "\n";
 
-    std::ifstream ifs(headerFilename);
-    const std::string headerContent{ std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>() };
-
-    const auto interface = script_core->getInterface("TestScript", headerContent);
-    const auto module = script_core->newScriptModule(interface, inputFilename);
+    // std::ifstream ifs(headerFilename);
+    // const std::string headerContent{ std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>() };
+    //
+    // const auto interface = script_core->getInterface("TestScript", headerContent);
+    const auto module = script_core->newScriptModule(inputFilename);
 
     dumpFile(module.get(), outputFilename.getValue());
 

--- a/as/core/core_compile.cpp
+++ b/as/core/core_compile.cpp
@@ -13,6 +13,7 @@
 
 #include "core_compile.h"
 
+#include <fstream>
 #include <llvm/Support/TargetSelect.h>
 
 namespace
@@ -69,6 +70,29 @@ void CoreCompile::registerInstance(void* instance, const std::string& instance_n
     {
         language->registerInstance(instance, instance_name, i);
     }
+}
+
+std::shared_ptr<ScriptModuleCompile> CoreCompile::newScriptModule(
+        const std::string& filename,
+        const std::string& language_name)
+{
+    auto language = getLanguage(resolveLanguageName(filename, language_name));
+    auto language_script = language->newScript();
+    auto header = language_script->findHeader(filename);
+
+    if (header.empty())
+        return nullptr;
+
+    std::filesystem::path file_path(std::filesystem::path(filename).parent_path());
+    std::filesystem::path header_path = file_path / header;
+
+    std::ifstream ifs(header_path);
+    const std::string header_content{ std::istreambuf_iterator<char>(ifs), std::istreambuf_iterator<char>() };
+
+    const auto interface = getInterface("TestScript", header_content);
+
+    language_script->load(m_base_path / filename);
+    return std::make_shared<ScriptModuleCompile>(ir::safe_name(filename), interface, language_script, *m_ts_context.getContext(), m_add_init);
 }
 
 std::shared_ptr<ScriptModuleCompile> CoreCompile::newScriptModule(

--- a/as/core/core_compile.h
+++ b/as/core/core_compile.h
@@ -29,6 +29,9 @@ public:
 
     void registerInstance(void* instance, const std::string& instance_name, const ScriptInterface& interface);
 
+    std::shared_ptr<ScriptModuleCompile> newScriptModule(const std::string& filename,
+        const std::string& language_name = "");
+
     std::shared_ptr<ScriptModuleCompile> newScriptModule(const ScriptInterface& interface, const std::string& filename,
         const std::string& language_name = "");
 

--- a/as/core/ir.cpp
+++ b/as/core/ir.cpp
@@ -2,6 +2,10 @@
 // Created by Alex Zelenshikov on 07.05.2024.
 //
 
+#include <fstream>
+#include <regex>
+#include <sstream>
+
 #include "llvm/IR/IRBuilder.h"
 
 namespace as::ir
@@ -167,5 +171,39 @@ llvm::Function* createInitFunc(llvm::Module& module,
 
     return init_func;
 }
+
+std::string getImplements(const std::string& filepath, const std::string& pattern)
+{
+    std::ifstream file(filepath);
+    if (!file.is_open())
+    {
+        return "";
+    }
+
+    char buffer[1025];  // Buffer to store up to 1024 characters + null terminator
+    file.read(buffer, 1024);  // Read the first 1024 characters from the file
+    buffer[file.gcount()] = '\0';  // Ensure null termination
+
+    std::string content(buffer);  // Convert buffer to std::string for easier processing
+    std::istringstream iss(content);  // Use istringstream to read line by line
+    std::string line;
+
+    std::regex implements("implements\\s+\"([^\"]+)\"");
+
+    while (std::getline(iss, line))
+    {
+        if (line.rfind(pattern, 0) != 0)
+            continue;
+
+        std::smatch matches;
+        if (!std::regex_search(line, matches, implements) || matches.size() != 2)
+            continue;
+
+        return matches[1].str();
+    }
+
+    return "";
+}
+
 
 } // namespace as::ir

--- a/as/core/ir.h
+++ b/as/core/ir.h
@@ -149,6 +149,8 @@ namespace as::ir
                                    llvm::GlobalVariable* runtime,
                                    const std::string& runtime_name);
 
+    std::string getImplements(const std::string& filepath, const std::string& pattern);
+
 } // namespace as
 
 #endif //AS_PROTO_IR_BUILD_HELPERS_H

--- a/as/core/language_script.h
+++ b/as/core/language_script.h
@@ -31,6 +31,8 @@ struct ILanguageScript
 
     virtual void load(const std::string& filename) = 0;
 
+    virtual std::string findHeader(const std::string& filename) = 0;
+
     virtual std::unique_ptr<llvm::Module> createModule(llvm::LLVMContext& context) = 0;
 
     virtual llvm::Function* buildModule(const std::string& init_name,

--- a/as/languages/ivnscript/is_language_script.cpp
+++ b/as/languages/ivnscript/is_language_script.cpp
@@ -22,6 +22,8 @@ IvnScriptLanguageScript::IvnScriptLanguageScript()
 
 void IvnScriptLanguageScript::load(const std::string& filename)
 {
+    std::cout << filename << " -> " << ir::getImplements(filename, "//") << std::endl;
+
     m_filename = filename;
 
     std::ifstream ifs(m_filename);
@@ -33,6 +35,11 @@ void IvnScriptLanguageScript::load(const std::string& filename)
     for (const auto &error: errors) {
       std::cerr << m_filename << ":" << error.line << ":" << error.column << ": error: " << error.message << "\n";
     }
+}
+
+std::string IvnScriptLanguageScript::findHeader(const std::string& filename)
+{
+    return ir::getImplements(filename, "//");
 }
 
 std::unique_ptr<llvm::Module> IvnScriptLanguageScript::createModule(

--- a/as/languages/ivnscript/is_language_script.h
+++ b/as/languages/ivnscript/is_language_script.h
@@ -22,6 +22,8 @@ public:
 
     void load(const std::string& filename) override;
 
+    std::string findHeader(const std::string& filename) override;
+
     std::unique_ptr<llvm::Module> createModule(llvm::LLVMContext& context) override;
 
     llvm::Function* buildModule(const std::string& init_name,

--- a/as/languages/ivnscript/script/tokenizer.cpp
+++ b/as/languages/ivnscript/script/tokenizer.cpp
@@ -46,14 +46,7 @@ void collectString(Token& token) {
   }
 }
 
-bool moveToken(Token& token) {
-  // move to the end of current token
-  const int length = token.type == TOK_STRING ? token.length + 1 : token.length;
-  token.text += length;
-  token.column += length;
-  token.length = 0;
-
-  // find first non-space symbol
+void skipSpaces(Token& token) {
   while (isspace(*token.text)) {
     if (*token.text == '\n') {
       token.line++;
@@ -64,6 +57,41 @@ bool moveToken(Token& token) {
 
     token.text++;
   }
+}
+
+bool skipComments(Token& token) {
+  const auto c = *token.text;
+  if (c != '/')
+    return false;
+  const auto c1 = token.text[1];
+  if (c1 != '/')
+    return false;
+
+  token.text += 2;
+  token.column += 2;
+  while (*token.text != '\n') {
+    token.column++;
+    token.text++;
+  }
+
+  return true;
+}
+
+void skipSpacesAndComments(Token& token) {
+  do {
+    skipSpaces(token);
+  } while (skipComments(token));
+}
+
+bool moveToken(Token& token) {
+  // move to the end of current token
+  const int length = token.type == TOK_STRING ? token.length + 1 : token.length;
+  token.text += length;
+  token.column += length;
+  token.length = 0;
+
+  // find first non-space symbol and non-comments symbols
+  skipSpacesAndComments(token);
 
   const auto c = *token.text;
   if (!c) {

--- a/as/languages/lua/lua_language_script.h
+++ b/as/languages/lua/lua_language_script.h
@@ -34,6 +34,11 @@ public:
 
     void load(const std::string& filename) override;
 
+    std::string findHeader(const std::string& filename) override
+    {
+        return "";
+    }
+
     std::unique_ptr<llvm::Module> createModule(llvm::LLVMContext& context) override;
 
     llvm::Function* buildModule(const std::string& init_name,

--- a/as/languages/squirrel/sq_language_script.h
+++ b/as/languages/squirrel/sq_language_script.h
@@ -32,6 +32,11 @@ public:
 
     void load(const std::string& filename) override;
 
+    std::string findHeader(const std::string& filename) override
+    {
+        return "";
+    }
+
     std::unique_ptr<llvm::Module> createModule(llvm::LLVMContext& context) override;
 
     llvm::Function* buildModule(const std::string& init_name,

--- a/as/languages/typescript/ts_language_script.h
+++ b/as/languages/typescript/ts_language_script.h
@@ -16,6 +16,11 @@ public:
 
     void load(const std::string& filename) override;
 
+    std::string findHeader(const std::string& filename) override
+    {
+        return "";
+    }
+
     std::unique_ptr<llvm::Module> createModule(llvm::LLVMContext& context) override;
 
     llvm::Function* buildModule(const std::string& init_name,

--- a/cmake/LLVMMacros.cmake
+++ b/cmake/LLVMMacros.cmake
@@ -49,7 +49,7 @@ macro(target_link_scripts target)
         add_custom_command(OUTPUT ${bc_target_header}
             OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/${source}.ll
             WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-            COMMAND asc ${source} -h ${CMAKE_CURRENT_SOURCE_DIR}/${source_file_path}/${source_file_name}.h -o ${CMAKE_CURRENT_BINARY_DIR}/${source}.ll
+            COMMAND asc ${source} -o ${CMAKE_CURRENT_BINARY_DIR}/${source}.ll
             DEPENDS asc ${CMAKE_CURRENT_SOURCE_DIR}/${source}
             VERBATIM
         )

--- a/sandbox/CMakeLists.txt
+++ b/sandbox/CMakeLists.txt
@@ -41,7 +41,7 @@ target_link_libraries(SandboxTests
 add_executable(SandboxCompiler
     main_compiler.cpp)
 
-target_link_scripts(SandboxCompiler scripts/test_script.is)
+target_link_scripts(SandboxCompiler scripts/test_1.is)
 target_link_libraries(SandboxCompiler
     IvnScriptIntegration
 )

--- a/sandbox/main_compiler.cpp
+++ b/sandbox/main_compiler.cpp
@@ -22,7 +22,7 @@ int main()
     core->registerLanguage("is", std::make_shared<as::IvnScriptLanguage>());
     core->registerRuntime(std::make_shared<as::IvnScriptLanguageRuntime>("CompileDemo"));
 
-    const auto module = core->newScriptModule<TestScript>("scripts/test_script.is");
+    const auto module = core->newScriptModule<TestScript>("scripts/test_1.is");
     const auto instance(module->newInstance());
     assert(instance->foo(10, 20) == 30);
     assert(instance->bar(10) == 100);

--- a/sandbox/scripts/test_1.is
+++ b/sandbox/scripts/test_1.is
@@ -1,3 +1,5 @@
+// implements "test_script.h"
+
 function foo(a, b)
 {
     return a + b;

--- a/sandbox/scripts/test_script.is
+++ b/sandbox/scripts/test_script.is
@@ -1,9 +1,0 @@
-function foo(a, b)
-{
-    return a + b;
-}
-
-function bar(a)
-{
-    return a * 10;
-}


### PR DESCRIPTION
В интерфейсе `ILanguageScript` появилась функция `findHeader` которая возвращает имя заголовочного файла, необходимого для компиляции данного скрипта. Путь до заголовочного файла - относительно пути до файла скрипта. Так же у `CoreCompile` можно запросить `newModule` передав только имя файла. В этом случае интерфейс будет получен автоматически из заголовочного файла. Если возникнут какие-либо проблемы - тихонько вернется `nullptr`

Эта функциональность используется только для компиляции. Материализация работает "по старому" и заголовочный файл даже не читается

В `ir` добавилась функция `getImplements(filename, pattern)`, которая читает первые 1024 символов файла (считая что файл ASCII), находит там строку, которая начинается с `pattern` и в которой есть регулярное выраение `implements\s+\"([^\"]+)\"`. Если такая строка находится - возвращает первую группу из регулярного выражения. Собственно предполагается использовать для поиска связанного заголовочного файла, считая что он задан через однострочный комментарий и ключевое слово `implements`

Вот пример для моего скрипта (я решил что комментарии начинаются с `//` - как в ~~JavaScript~~ C++):
```
class IvnScriptLanguageScript final : public ILanguageScript
{
// ...
    std::string findHeader(const std::string& filename) override
    {
        return ir::getImplements(filename, "//");
    }
// ...
}
```

Для LUA, насколько я понимаю будет вот так:
```
class LuaScriptLanguageScript final : public ILanguageScript
{
// ...
    std::string findHeader(const std::string& filename) override
    {
        return ir::getImplements(filename, "--");
    }
// ...
}
```

Теперь про нюансы, в общем-то они все связаны с текущей реализацией парсера С++:
- Интерфейс в заголовочном файле должен называться `TestScript` и никак иначе. Это связано с тем, как работает `getInterface` у парсера. `"TestScript"` захардкожено в `core_compile.cpp`:
```
const auto interface = getInterface("TestScript", header_content);
```
- Этот заголовочный файл нельзя использовать в обычном коде приложения, потому что парсер не переживает наличие макроса `DEFINE_SCRIPT_INTERFACE`, а без него обычный код не заработает. Второй момент - кажется парсер подругивается на `#pragma once` (выдает `warning: #pragma once in main file`), но нормально переживает. ifdef guard работает без warnings
